### PR TITLE
Fixes qtips on timetable with white background

### DIFF
--- a/indico_themes_canonical/static/css/ubuntu-summit/_notifications.css
+++ b/indico_themes_canonical/static/css/ubuntu-summit/_notifications.css
@@ -41,6 +41,11 @@
   text-decoration: underline;
 }
 
+/* Style for white qtips found in the timetable */
+.qtip-default.qbubble.balloon-qtip .qtip-content .balloon * {
+  color: var(--brand-black) !important;
+}
+
 /* For pop up corner message notifications */
 .corner-message.highlight {
   background: var(--brand-white);


### PR DESCRIPTION
## Done

Adds style to account for qtips with white background found in the timetable

## QA

- run indico with atleast one event in the timetable
- go to the timetable and clock on an event, a white pop up box with event details should appear and be readable

