### PR TITLE
Fix ticket button on orange background

### DIFF
--- a/indico_themes_canonical/static/css/ubuntu-summit/_icons.css
+++ b/indico_themes_canonical/static/css/ubuntu-summit/_icons.css
@@ -7,6 +7,9 @@
 .icon-ticket::before {
   color: var(--brand-warm-grey);
 }
+.i-button.accept.icon-ticket:not(.label):not(.borderless):not(.text-color)::before {
+  color: var(--brand-white);
+}
 
 /* Style for location icon */
 .icon-location::before {


### PR DESCRIPTION
<img width="1178" alt="image" src="https://user-images.githubusercontent.com/607198/199000286-50b0f204-a7cd-4dbb-863b-2c9013ae1031.png">

In combination with a change in the customization files, this makes the icon show up right on the ticket button.