### PR TITLE
Update timetable style

### DIFF
--- a/indico_themes_canonical/static/css/ubuntu-summit/_buttons.css
+++ b/indico_themes_canonical/static/css/ubuntu-summit/_buttons.css
@@ -38,6 +38,7 @@
 .i-button.highlight.text-color.outline,
 .i-button:not(.subtle),
 .i-button:not(.label),
+.toolbar .i-button:not(.label),
 .i-button.highlight:not(.label):not(.borderless):not(.text-color),
 .ui.modal .actions .ui.button:not(.highlighted):not(.primary) {
   background: var(--brand-white);
@@ -83,4 +84,12 @@
 .ui-button:hover {
   background: var(--brand-off-white) !important;
   color: var(--brand-black);
+}
+
+.item-subitems.toolbar a.i-button.js-switch-view.highlight {
+  font-weight: 500;
+}
+
+.item-subitems.toolbar a.i-button.js-switch-view.highlight:hover {
+  background: var(--brand-white);
 }

--- a/indico_themes_canonical/static/css/ubuntu-summit/_icons.css
+++ b/indico_themes_canonical/static/css/ubuntu-summit/_icons.css
@@ -31,7 +31,12 @@
   color: var(--brand-warm-grey);
 }
 
+.i-button.icon-time::before {
+  color: var(--brand-black);
+}
+
 /* Style for chairperson icon */
 .icon-user-chairperson::before {
   color: var(--brand-warm-grey);
 }
+

--- a/indico_themes_canonical/static/css/ubuntu-summit/_icons.css
+++ b/indico_themes_canonical/static/css/ubuntu-summit/_icons.css
@@ -39,4 +39,3 @@
 .icon-user-chairperson::before {
   color: var(--brand-warm-grey);
 }
-

--- a/indico_themes_canonical/static/css/ubuntu-summit/index.css
+++ b/indico_themes_canonical/static/css/ubuntu-summit/index.css
@@ -31,6 +31,7 @@
 @import "side-navigation.css";
 @import "surveys.css";
 @import "top-navigation.css";
+@import "timetable.css";
 
 /* 
 TEMP STYLES

--- a/indico_themes_canonical/static/css/ubuntu-summit/timetable.css
+++ b/indico_themes_canonical/static/css/ubuntu-summit/timetable.css
@@ -1,0 +1,59 @@
+/* ---------- Style for timetable ---------- */
+
+/* Day selection */
+.ui-tabs-nav {
+  border-color: rgba(0, 0, 0, 0.56);
+}
+
+.ui-tabs-nav li.ui-tabs-tab {
+  border-top-right-radius: 0.25rem;
+  border-top-left-radius: 0.25rem;
+  border-color: rgba(0, 0, 0, 0.56);
+}
+
+.ui-tabs-nav li.ui-tabs-tab a.ui-tabs-anchor {
+  padding: 10px 16px 5px;
+  color: var(--brand-black);
+}
+
+.ui-tabs-nav li.ui-tabs-tab:not(.ui-state-active) a.ui-tabs-anchor:hover {
+  background: var(--brand-off-white) !important;
+}
+.ui-tabs-nav .ui-state-active a {
+  color: var(--brand-black) !important;
+  font-weight: 500;
+}
+
+/* Button bar (print, PDF, etc...) */
+.tabExtraButtons {
+  background-color: var(--brand-white);
+  border: 1px solid rgba(0, 0, 0, 0.56);
+  border-radius: 0.125rem;
+  box-shadow: none;
+  margin-top: 15px;
+}
+
+.tabExtraButtons .buttonContainer {
+  border-left: 1px solid rgba(0, 0, 0, 0.56);
+  padding: .125rem .5rem;
+}
+
+.tabExtraButtons .buttonContainerLeft {
+  border-left: none;
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.tabExtraButtons .buttonContainerRight {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.tabExtraButtons .buttonContainer:hover {
+  background: var(--brand-off-white);
+}
+
+/* Colour picker qtip in session edit */
+.qtip.palette-picker-qtip {
+  background: var(--brand-white);
+}


### PR DESCRIPTION
- [x] Adjust the grey button bar to be more in line with our theme buttons (bgcolor, color, active color, remove shadow, etc)
- [x] Adjust day tabs to add a little more padding and maybe font size (making them a bit easier to click)
- [x] More reasonable border-radius on the day tabs.
- [x] The time symbol and the actual time wrap in the tooltip view, this doesn't happen on the [indico sandbox](https://sandbox.getindico.io/event/2584/timetable/#20221013). Same on the tooltip in the session view.
- [x] In the session detail view (click on the icon next to "Session" in the tooltip), the active colors of the buttons seem to be flipped. When in timetable view, "Contribution list" is bold, and vice versa.
- [x] In session view, click edit. The color picker has a black background, which makes it a bit harder to judge how the colors will look.

- [ ] In fullscreen view, the room names wrap. In above shot, Breakout 3 should be centered on the right most column of events. **I can't replicate this problem?**
- [ ] Best possible adjustments so the schedule works well on a mobile view. People will be viewing this on mobile all day at the conference. **separate pr**
- [ ] Adjust width to make better use of space on desktop **separate pr**
- [ ] The colors here are hardcoded. I believe we would need to hook in to https://github.com/indico/indico/blob/master/indico/web/forms/colors.py to change them, but if we can provide a color palette that fits a bit better to our default theme this would be great! **separate pr**
