### PR TITLE
Fix logo alignment

### DIFF
--- a/indico_themes_canonical/static/css/_default/_forms.css
+++ b/indico_themes_canonical/static/css/_default/_forms.css
@@ -40,6 +40,11 @@ input[type]:not([type="number"]):not([type="checkbox"]):not([type="radio"]):not(
   width: 100%;
 }
 
+// Override default error input bg color width default Vanilla
+.ui.form .field.error {
+  background-color: #f8e9e8;
+}
+
 /* Style for checkboxes */
 .i-checkbox input,
 .ui.checkbox label:before {

--- a/indico_themes_canonical/static/css/_default/_forms.css
+++ b/indico_themes_canonical/static/css/_default/_forms.css
@@ -40,7 +40,7 @@ input[type]:not([type="number"]):not([type="checkbox"]):not([type="radio"]):not(
   width: 100%;
 }
 
-// Override default error input bg color width default Vanilla
+/* Override default error input bg color width default Vanilla */
 .ui.form .field.error {
   background-color: #f8e9e8;
 }

--- a/indico_themes_canonical/static/css/_default/_forms.css
+++ b/indico_themes_canonical/static/css/_default/_forms.css
@@ -1,7 +1,7 @@
 /* ---------- Style for general forms ---------- */
 
 /* Style for form field container */
-.i-form .form-group .form-field {
+.i-form .form-group .form-field input {
   padding-left: 0;
 }
 

--- a/indico_themes_canonical/static/css/_default/_forms.css
+++ b/indico_themes_canonical/static/css/_default/_forms.css
@@ -41,8 +41,9 @@ input[type]:not([type="number"]):not([type="checkbox"]):not([type="radio"]):not(
 }
 
 /* Override default error input bg color width default Vanilla */
-.ui.form .field.error {
+.ui.form .field.error input {
   background-color: #f8e9e8;
+  color: #f8e9e8;
 }
 
 /* Style for checkboxes */

--- a/indico_themes_canonical/static/css/_default/header.css
+++ b/indico_themes_canonical/static/css/_default/header.css
@@ -62,6 +62,7 @@ Event Logo placement
   position: absolute;
   right: 60px;
   max-height: 12.5rem;
+  top: -1rem;
 }
 
 /*

--- a/indico_themes_canonical/static/css/_default/header.css
+++ b/indico_themes_canonical/static/css/_default/header.css
@@ -60,9 +60,10 @@ Event Logo placement
 
 .confTitleBox .confLogo {
   position: absolute;
-  right: 60px;
+  right: 1em;
   max-height: 12.5rem;
-  top: -1rem;
+  max-width: 12.5rem;
+  top: -0.5em;
 }
 
 /*


### PR DESCRIPTION
## Done
Fix logo alignment.

## QA
Go to /event/1/ and check that the Ubuntu summit logo is vertically aligned