### PR TITLE
WD-9542 - make participants list more readable

### DIFF
--- a/indico_themes_canonical/static/css/_default/participant-list.css
+++ b/indico_themes_canonical/static/css/_default/participant-list.css
@@ -16,3 +16,9 @@
 .i-table.tablesorter-header:hover {
   background-color: var(--brand-off-white);
 }
+
+.list table.i-table {
+  display: block;
+  overflow-x: auto;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Done

Data on participants list is large and therefore not readable on most screens. Made the table horizontally scrollable to fit all the data.

## QA
Go to participants list of any event and make sure the table is readable and horizontally scrollable.

## Issue
[WD-9542](https://warthogs.atlassian.net/browse/WD-9542)
Fixes https://github.com/canonical/canonical-indico-customization-files/issues/26

[WD-9542]: https://warthogs.atlassian.net/browse/WD-9542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ