### PR TITLE
Make the month readability in the date picker component

### DIFF
--- a/indico_themes_canonical/static/css/_default/registration.css
+++ b/indico_themes_canonical/static/css/_default/registration.css
@@ -214,3 +214,10 @@ button.SingleDatePickerInput_calendarIcon {
     margin-left: 1rem;
   }
 }
+
+/* Style to improve the calendar picker */
+
+/* Workaround for https://github.com/canonical/canonical-indico-customization-files/issues/29 */
+.CalendarMonth_caption select.datepicker-select:first-child {
+  padding-left: 3rem !important;
+}


### PR DESCRIPTION
## Done

Added a small bit of padding to the month select box so the month is readable with the previous month button overlapping it.

## QA
1. Open this URL: https://events.canonical.com/event/55/registrations/43/edit
2. Select a flight date/time
3. Add the styling in the inspector and check you can see all the month

## Screenshot
![image](https://github.com/canonical/canonical-indico-customization-files/assets/1413534/08a22420-3f91-49f1-9037-d9fd3d08c9e3)


Fixes https://github.com/canonical/canonical-indico-customization-files/issues/29