### PR TITLE
Fix UL spacing issue in registration form

### DIFF
--- a/indico_themes_canonical/static/css/_default/registration.css
+++ b/indico_themes_canonical/static/css/_default/registration.css
@@ -141,6 +141,10 @@ button.SingleDatePickerInput_calendarIcon {
   font-weight: 300;
 }
 
+.regform-section ul {
+  padding-left: 1rem;
+}
+
 .ui.form .field > label {
   font-size: 1rem;
   font-weight: 400;


### PR DESCRIPTION
Bulleted lists in registration form flow outside of frame. This PR adds a bit of padding on the left to compensate for the bullet character.

Before change:
![Screenshot_20240628_104735](https://github.com/canonical/canonical-indico-themes/assets/16280777/4f033365-eae1-4edb-91a9-551ef0ac16e7)

After Change:
![Screenshot_20240628_104621](https://github.com/canonical/canonical-indico-themes/assets/16280777/11bc9a98-8988-4ac8-9e35-85a8dd3e67dc)
