### PR TITLE
Fix participant list first column cells hiding the table header

### DIFF
--- a/indico_themes_canonical/static/css/_default/participant-list.css
+++ b/indico_themes_canonical/static/css/_default/participant-list.css
@@ -27,6 +27,7 @@
 table.i-table thead {
   position: sticky;
   top: 0;
+  z-index: 3;
 }
 
 table thead th:first-child,


### PR DESCRIPTION
## Done

1. Added `z-index: 3` to the participant list table header style to ensure it is stacked above the table body

Fixes #50 

## QA

1. Visit https://events.canonical.com/event/55/registrations/participants
2. Scroll the table down until you see a first name overlap the first name header.
3. Copy the new style rule to the inspector on the `thead`
4. Confirm the table header is now stacked on top of the row.
5. Scroll the table horizontally and vertically and verify that the sticky first row and first column still work as expected.

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/52b5cd52-3857-41c9-9995-3c225d7eff89)
After:
![image](https://github.com/user-attachments/assets/1cbfb640-6f52-4be1-a0bf-f43d8ab3c290)
