### PR TITLE
feat(toc): Add a JS to render a table of contents on long page

### DIFF
--- a/indico_themes_canonical/static/js/default.js
+++ b/indico_themes_canonical/static/js/default.js
@@ -168,10 +168,41 @@ function renderCounts(counts, table) {
   }
 }
 
+/* Renders a table of contents based on the h2 and h3 elements in the page content */
+function renderTableOfContents() {
+  const content = document.querySelector(".page-content");
+  if (!content) {
+    return;
+  }
+
+  const headings = content.querySelectorAll("h2, h3");
+  if (headings.length <= 3) {
+    return;
+  }
+  const tocList = document.createElement("ol");
+  const tocHeading = document.createElement("h3");
+  tocHeading.innerText = "Table of Contents";
+
+  headings.forEach((heading) => {
+    const id = heading.innerText.replace(/\s+/g, "-").toLowerCase();
+    heading.id = id;
+    const listItem = document.createElement("li");
+    const anchor = document.createElement("a");
+    anchor.href = `#${id}`;
+    anchor.innerText = heading.innerText;
+    listItem.appendChild(anchor);
+    tocList.appendChild(listItem);
+  });
+
+  content.prepend(tocList);
+  content.prepend(tocHeading);
+}
+
 /* --------- Setup on window load ---------- */
 window.addEventListener("load", function () {
   addMetaTag();
   moveHeaderNav();
   setupSideNavigations(".conf_leftMenu");
   addCountsToTableHead();
+  renderTableOfContents();
 });


### PR DESCRIPTION
## Done

Added a script to pick up the headings of the document and prepend a TOC

## QA

- Go to https://events.canonical.com/event/90/page/455-visas-entry-documents
- Copy the script into the console
- Run the function and see that it adds a TOC to the top of the page
- Check the links work
- _ignore the other contents, that will be removed_