### PR TITLE
fix(toc): Add H4 to the TOC generator

### DIFF
--- a/indico_themes_canonical/static/js/default.js
+++ b/indico_themes_canonical/static/js/default.js
@@ -171,14 +171,12 @@ function renderCounts(counts, table) {
 /* Renders a table of contents based on the h2 and h3 elements in the page content */
 function renderTableOfContents() {
   const content = document.querySelector(".page-content");
-  if (!content) {
+  const headings = content.querySelectorAll("h2, h3", "h4");
+  // Do not render if there is no content body or less than three headings
+  if (!content && headings.length <= 3) {
     return;
   }
 
-  const headings = content.querySelectorAll("h2, h3");
-  if (headings.length <= 3) {
-    return;
-  }
   const tocList = document.createElement("ol");
   const tocHeading = document.createElement("h3");
   tocHeading.innerText = "Table of Contents";

--- a/indico_themes_canonical/static/js/default.js
+++ b/indico_themes_canonical/static/js/default.js
@@ -173,7 +173,7 @@ function renderTableOfContents() {
   const content = document.querySelector(".page-content");
   const headings = content.querySelectorAll("h2, h3", "h4");
   // Do not render if there is no content body or less than three headings
-  if (!content && headings.length <= 3) {
+  if (!content || headings.length <= 3) {
     return;
   }
 


### PR DESCRIPTION
## Done

- Refactored the activation checks
- Added `H4` as a selected heading for the TOC

## QA

- Go to https://events.canonical.com/event/90/page/455-visas-entry-documents
- Copy the script into the console
- Run the function and see that it adds a TOC to the top of the page
- Check the links work