### PR TITLE
fix: Update the table selectors for the latest version of Indico

### DIFF
--- a/indico_themes_canonical/static/css/_default/participant-list.css
+++ b/indico_themes_canonical/static/css/_default/participant-list.css
@@ -37,3 +37,12 @@ table tbody td:first-child {
   z-index: 2;
   background: var(--brand-white);
 }
+
+.content.active {
+  overflow-x: scroll;
+}
+
+.ui.table {
+  width: 100vw;
+  table-layout: auto !important;
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-themes-canonical
-version = 2.0.1
+version = 2.0.2
 url = https://github.com/canonical/canonical-indico-themes
 license = Apache 2.0
 author = Peter French


### PR DESCRIPTION
## Done

Update some styling for the new version of Indico

## QA

1. Join the VPN
2. Visit https://events.staging.canonical.com/event/1/registrations/participants
3. manually apply the styling to the inspector
4. See the table is scrollable and better.