### PR TITLE
fix: Align the date picker

### DIFF
--- a/indico_themes_canonical/static/css/_default/registration.css
+++ b/indico_themes_canonical/static/css/_default/registration.css
@@ -141,10 +141,6 @@ button.SingleDatePickerInput_calendarIcon {
   font-weight: 300;
 }
 
-.regform-section ul {
-  padding-left: 1rem;
-}
-
 .ui.form .field > label {
   font-size: 1rem;
   font-weight: 400;

--- a/indico_themes_canonical/static/css/_default/registration.css
+++ b/indico_themes_canonical/static/css/_default/registration.css
@@ -141,6 +141,14 @@ button.SingleDatePickerInput_calendarIcon {
   font-weight: 300;
 }
 
+.regform-section ul {
+  padding-left: 1rem;
+}
+
+.regform-section .DayPicker ul {
+  padding-left: 0;
+}
+
 .ui.form .field > label {
   font-size: 1rem;
   font-weight: 400;

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-themes-canonical
-version = 2.0.2
+version = 2.0.3
 url = https://github.com/canonical/canonical-indico-themes
 license = Apache 2.0
 author = Peter French


### PR DESCRIPTION
## Done
1. Remove the padding on the date picker dropdown
2. Bumped the version to `2.0.3`
