### PR TITLE
feat(toc): Disable TOC on the overview page

### DIFF
--- a/indico_themes_canonical/static/js/default.js
+++ b/indico_themes_canonical/static/js/default.js
@@ -172,8 +172,8 @@ function renderCounts(counts, table) {
 function renderTableOfContents() {
   const content = document.querySelector(".page-content");
   const headings = content.querySelectorAll("h2, h3, h4");
-  // Do not render if there is no content body or less than three headings
-  if (!content || headings.length <= 3) {
+  // Do not render if there is no content body or less than three headings or if on an overview page
+  if (!content || headings.length <= 3 || isOverviewPage()) {
     return;
   }
 
@@ -194,6 +194,15 @@ function renderTableOfContents() {
 
   content.prepend(tocList);
   content.prepend(tocHeading);
+}
+
+/* Returns true  if the current page URL structure ends with /overview */
+function isOverviewPage() {
+  const lastPath = window.location.pathname
+    .split("/")
+    .filter((s) => s)
+    .pop();
+  return lastPath === "overview";
 }
 
 /* --------- Setup on window load ---------- */

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = indico-plugin-themes-canonical
-version = 2.0.3
+version = 2.0.4
 url = https://github.com/canonical/canonical-indico-themes
 license = Apache 2.0
 author = Peter French


### PR DESCRIPTION
## Done
1. Disable the TOC function from running on the overview page
2. Bump the package version from `2.0.3` to `2.0.4`

## QA
1. Check the code