### PR TITLE
fix(Forms): Align checkboxes and radios with their labels

### DIFF
--- a/indico_themes_canonical/static/css/_default/_forms.css
+++ b/indico_themes_canonical/static/css/_default/_forms.css
@@ -41,6 +41,15 @@ input[type]:not([type="number"]):not([type="checkbox"]):not([type="radio"]):not(
 
 /* Style for checkboxes */
 
+.ui.radio.checkbox {
+  line-height: 1.5rem;
+}
+
+.ui.radio.checkbox .box:before, .ui.radio.checkbox label:before,
+.ui.radio.checkbox .box:after, .ui.radio.checkbox label:after {
+  top: 5px;
+}
+
 .i-checkbox input,
 .ui.checkbox label:before {
   border-color: var(--brand-black) 111;

--- a/indico_themes_canonical/static/css/_default/_forms.css
+++ b/indico_themes_canonical/static/css/_default/_forms.css
@@ -41,15 +41,6 @@ input[type]:not([type="number"]):not([type="checkbox"]):not([type="radio"]):not(
 
 /* Style for checkboxes */
 
-.ui.checkbox {
-  line-height: 1.5rem;
-}
-
-.ui.radio.checkbox .box:before, .ui.radio.checkbox label:before,
-.ui.radio.checkbox .box:after, .ui.radio.checkbox label:after {
-  top: 5px;
-}
-
 .i-checkbox input,
 .ui.checkbox label:before {
   border-color: var(--brand-black) 111;


### PR DESCRIPTION
Scopes the line-height override of the Semantic UI [radio](https://semantic-ui.com/modules/checkbox.html) applied in https://github.com/canonical/canonical-indico-themes/pull/56 to the radio only. Previously it was also applying to the checkbox element, which caused misalignment of the checkbox and its label.

At first, ([commit](https://github.com/canonical/canonical-indico-themes/commit/b936d359bdd498d433ef3d85d8be5e5fc58422ab)) I entirely removed the line-height and radio positioning overrides to stay closer to Semantic UI. Then I decided to only remove the line-height override from the checkbox (not the radio checkbox), to make a smaller change.

Fixes #61 

### QA

1. Open a page with checkboxes and radios, like https://events.canonical.com/event/145/registrations/133/edit
2. Use dev tools to increase specificity of the `ui.checkbox` `line-height: 1.5rem` style to `ui.radio.checkbox`. 
3. Verify that the radios and checkboxes are aligned with their labels, and checkmarks are properly contained/aligned within their boxes.

### Screenshots

#### Before

Checkbox (misaligned)
<img width="265" height="230" alt="Screenshot_2026-01-14_12-07-17" src="https://github.com/user-attachments/assets/5f006eca-bdb8-4d77-95c6-383a71a9f0bc" />

Radio (no issues)
<img width="265" height="230" alt="Screenshot_2026-01-14_12-07-32" src="https://github.com/user-attachments/assets/8b97c911-cf1a-4c56-a950-50359082a8e6" />

#### After

Checkbox (aligned)
<img width="385" height="234" alt="Screenshot_2026-01-14_12-07-53" src="https://github.com/user-attachments/assets/4b7f0647-3235-4553-9477-f66f7468e7c7" />

Radio (no changes)
<img width="381" height="345" alt="Screenshot_2026-01-14_12-08-00" src="https://github.com/user-attachments/assets/20888dcd-4983-411b-a048-0b15b8a2f833" />


