### PR TITLE
fix: disabling TOC for both "event_id/overview" and "event_id"

### DIFF
--- a/indico_themes_canonical/static/js/default.js
+++ b/indico_themes_canonical/static/js/default.js
@@ -196,13 +196,14 @@ function renderTableOfContents() {
   content.prepend(tocHeading);
 }
 
-/* Returns true  if the current page URL structure ends with /overview */
+/* Returns true if the current page is the overview page.
+   Handles both /event/1/ and /event/1/overview URL forms. */
 function isOverviewPage() {
   const lastPath = window.location.pathname
     .split("/")
     .filter((s) => s)
     .pop();
-  return lastPath === "overview";
+  return lastPath === "overview" || /^\d+$/.test(lastPath);
 }
 
 /* --------- Setup on window load ---------- */


### PR DESCRIPTION
Currently, `isOverviewPage` checks if the last path of the URL is "overview", e.g. `/event/1/overview`. However, just `/event/1` also renders the same page, but since this URL returns `False`, it still renders TOC. This PR fixes it.